### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/data_prep/get_cityscapes_list.py
+++ b/data_prep/get_cityscapes_list.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import glob
 
@@ -15,15 +16,15 @@ def get_cityscapes_list_augmented(root, image_path, label_path, lst_path, is_fin
         if os.path.isfile(l):
             index += 1
             if index % 100 == 0:
-                print "%d out of %d done." % (index, len(all_images))
+                print("%d out of %d done." % (index, len(all_images)))
             if index % sample_rate != 2:
                 continue
             for i in range(1, 8):
                 train_lst.append([str(index), p, l, "512", str(256 * i)])
         else:
-            print "dismiss %s" % (p)
+            print("dismiss %s" % (p))
 
     train_out = open(lst_path, "w")
     for line in train_lst:
-        print >> train_out, '\t'.join(line)
-        print >> train_out, '\t'.join(line)
+        print('\t'.join(line), file=train_out)
+        print('\t'.join(line), file=train_out)

--- a/test/predict_full_image.py
+++ b/test/predict_full_image.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import ConfigParser
 import os
 import sys
@@ -84,13 +85,13 @@ class ImageListTester:
             idx += 1
             start_time = time.time()
             conf_lst.append(self.predict_single(item))
-            print 'Process %d out of %d image ... %s, time cost:%.3f, confidence:%.3f' % \
-                  (idx, len(img_list), item.strip().split('/')[-1], time.time() - start_time, conf_lst[-1][0])
+            print('Process %d out of %d image ... %s, time cost:%.3f, confidence:%.3f' % \
+                  (idx, len(img_list), item.strip().split('/')[-1], time.time() - start_time, conf_lst[-1][0]))
         conf_file = open(os.path.join(self.result_dir, self.model_prefix + str(self.model_epoch) + '.txt'), 'w')
         conf_lst.sort()
         for item in conf_lst:
 
-            print >> conf_file, "{}\t{}".format(item[1], item[0])
+            print("{}\t{}".format(item[1], item[0]), file=conf_file)
 
 
 if __name__ == '__main__':

--- a/train/train_model.py
+++ b/train/train_model.py
@@ -1,4 +1,5 @@
-from solver import Solver
+from __future__ import absolute_import
+from .solver import Solver
 import ConfigParser
 import sys
 

--- a/tusimple_duc/core/cityscapes_labels.py
+++ b/tusimple_duc/core/cityscapes_labels.py
@@ -3,6 +3,7 @@
 # Cityscapes labels
 #
 
+from __future__ import print_function
 from collections import namedtuple
 
 

--- a/tusimple_duc/core/cityscapes_loader.py
+++ b/tusimple_duc/core/cityscapes_loader.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import Queue
 import atexit
 import logging
@@ -7,7 +8,7 @@ import random
 import mxnet as mx
 import numpy as np
 
-import utils
+from . import utils
 
 
 class CityLoader(mx.io.DataIter):

--- a/tusimple_duc/core/utils.py
+++ b/tusimple_duc/core/utils.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import logging
 import math
 import os
@@ -10,7 +11,7 @@ import cv2 as cv
 import mxnet as mx
 import numpy as np
 
-import cityscapes_labels
+from . import cityscapes_labels
 
 
 # save symbol

--- a/tusimple_duc/networks/network_duc_hdc.py
+++ b/tusimple_duc/networks/network_duc_hdc.py
@@ -1,5 +1,6 @@
+from __future__ import absolute_import
 import mxnet as mx
-from resnet import get_resnet_hdc
+from .resnet import get_resnet_hdc
 
 
 def get_symbol_duc_hdc(label_num=19, ignore_label=255, bn_use_global_stats=True,

--- a/tusimple_duc/test/tester.py
+++ b/tusimple_duc/test/tester.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import math
 import os
 
@@ -6,7 +7,7 @@ import mxnet as mx
 import numpy as np
 from PIL import Image
 
-from predictor import Predictor
+from .predictor import Predictor
 
 from tusimple_duc.core import utils
 from tusimple_duc.core import cityscapes_labels


### PR DESCRIPTION
Partial fix for #3 

Make the minimal, safe changes required to convert the repo's code to be syntax compatible with both Python 2 and Python 3. More work _might_ be required to complete the port to Python 3 but this is a minimal, safe first step.

* [futurize stage 1](http://python-future.org/futurize_cheatsheet.html#step-1-modern-py2-code)
* `from __future__ import absolute_import`
* `from __future__ import print_function`